### PR TITLE
Fix top holders list rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,18 +516,18 @@ function updateTopHolders(holders) {
 
             cachedTopHolders = enriched;
 
-            list.innerHTML = '';
-            for (const holder of enriched) {
+            const rendered = await Promise.all(enriched.map(async holder => {
                 const short = `${holder.address.slice(0, 4)}...${holder.address.slice(-4)}`;
                 const displayText = await fetchHolderAsset(holder.address);
                 const percentText = `${holder.percentage.toFixed(1)}%`;
-                const li = document.createElement('li');
-                li.className = 'holder-entry';
-                li.innerHTML = `
-        <a class="address-link" href="https://solscan.io/account/${holder.address}" target="_blank">${short}</a>
-        <div class="holder-right">${displayText} <span style="color:#888; font-weight:normal;">(${percentText})</span></div>`;
-                list.appendChild(li);
-            }
+                return `
+    <li class="holder-entry">
+      <a class="address-link" href="https://solscan.io/account/${holder.address}" target="_blank">${short}</a>
+      <div class="holder-right">${displayText} <span style="color:#888; font-weight:normal;">(${percentText})</span></div>
+    </li>`;
+            }));
+
+            list.innerHTML = rendered.join('');
 
             isFirstLoad = false;
 
@@ -646,6 +646,7 @@ function updateTopHolders(holders) {
           fetchDevHistory(ca, solscanKey);
           fetchDevActivity(ca, solscanKey, heliusKey);
           if (holdersInterval) clearInterval(holdersInterval);
+          document.getElementById('holders-list').innerHTML = '<li>Loading Top Holders...</li>';
           fetchTopHolders(ca, solscanKey);
           holdersInterval = setInterval(() => fetchTopHolders(ca, solscanKey), 10000);
 


### PR DESCRIPTION
## Summary
- update `fetchTopHolders` to render all holders at once and keep old list visible during refresh
- show loading message when switching coins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850231e674c832b8113ac12d2ebf68b